### PR TITLE
turbo_page_requires_reload を使って TurboFrame の中からリダイレクトする

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -2,6 +2,7 @@ class MemosController < ApplicationController
   before_action :set_memo, only: %i[ show edit update destroy ]
 
   def index
+    flash.keep if turbo_frame_request?
     @memos = Memo.order(id: :desc)
   end
 

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -1,3 +1,5 @@
+<% turbo_page_requires_reload %>
+
 <p style="color: green"><%= notice %></p>
 
 <% content_for :title, "Memos" %>


### PR DESCRIPTION
## memos#index レスポンスの head タグ

### 2回目のリクエスト (303 redirect => GET + TurboFrame/TurboStream)

```html
<head>
  <meta name="turbo-visit-control" content="reload">
</head>
```

### 3回目のリクエスト (GET HTML)

```html
<head>
  <title>Memos</title>
  <meta name="viewport" content="width=device-width,initial-scale=1">
  <meta name="apple-mobile-web-app-capable" content="yes">
  <meta name="mobile-web-app-capable" content="yes">
  <meta name="csrf-param" content="authenticity_token" />
  <meta name="csrf-token" content="..." />

  <meta name="turbo-visit-control" content="reload">

  <link rel="icon" href="/icon.png" type="image/png">
  <link rel="icon" href="/icon.svg" type="image/svg+xml">
  <link rel="apple-touch-icon" href="/icon.png">
  <link rel="stylesheet" href="/assets/application-a287cdb7.css" data-turbo-track="reload" />
  <script src="/assets/application-bb3a7f6f.js" data-turbo-track="reload" type="module"></script>
  <link rel="stylesheet" href="/assets/application-a287cdb7.css" data-turbo-track="reload" />
</head>
```